### PR TITLE
58 linear angle tolerance fix

### DIFF
--- a/strainjedi/bmatrix.py
+++ b/strainjedi/bmatrix.py
@@ -349,20 +349,21 @@ def _bond_angle_derivatives(u, v):
 
     angle = ase.geometry.get_angles(u, v)  # angle between v and u
 
-    if angle == 180 or angle == 0:  # an auxiliary vector is used if linear angles are existing
-        (u, v), (lu, lv) = ase.geometry.conditional_find_mic([u, v], cell=None, pbc=None)
+    tolerance = 5e-6
+    if np.abs(np.radians(angle) - np.pi) < tolerance or np.abs(np.radians(angle)) < tolerance:   #an auxilliary vector is used if linear angles are existing
+        (u, v), (lu, lv) = ase.geometry.conditional_find_mic([u, v],cell=None,pbc=None)
         nu = u / lu
         nv = v / lv
-        if (np.arccos(np.dot(nu, (np.array([1, -1, 1]))))) == np.pi:
+        if np.abs((np.arccos(np.dot(nu, (np.array([1, -1, 1]))))) - np.pi) < tolerance:
             w = np.cross(nu, ([-1, 1, 1]))
         else:
             w = np.cross(nu, ([1, -1, 1]))
 
         nw = w / np.linalg.norm(w)
-        d_ba1 = (np.cross(nu, nw)) / np.linalg.norm(u)
-        d_ba2 = (-1 * ((np.cross(nu, nw)) / np.linalg.norm(u))) + (-1 * ((np.cross(nw, nv)) / np.linalg.norm(v)))
-        d_ba3 = (np.cross(nw, nv)) / np.linalg.norm(v)
-        d_ba = np.array([[d_ba1[0], d_ba2[0], d_ba3[0]]])
+        d_ba1 = (((np.cross(nu, nw))/np.linalg.norm(u)))
+        d_ba2 = (-1 * ((np.cross(nu, nw))/np.linalg.norm(u))) + (-1 * ((np.cross(nw, nv))/np.linalg.norm(v))) # equation to calculate dBA/dx [1]
+        d_ba3 = ((np.cross(nw, nv))/np.linalg.norm(v))
+        d_ba=np.array([[d_ba1[0], d_ba2[0], d_ba3[0]]])
 
     else:
         d_ba = np.radians(ase.geometry.get_angles_derivatives(u, v))

--- a/strainjedi/bmatrix.py
+++ b/strainjedi/bmatrix.py
@@ -350,20 +350,25 @@ def _bond_angle_derivatives(u, v):
     angle = ase.geometry.get_angles(u, v)  # angle between v and u
 
     tolerance = 5e-6
-    if np.abs(np.radians(angle) - np.pi) < tolerance or np.abs(np.radians(angle)) < tolerance:   #an auxilliary vector is used if linear angles are existing
-        (u, v), (lu, lv) = ase.geometry.conditional_find_mic([u, v],cell=None,pbc=None)
+    if np.abs(np.radians(angle) - np.pi) < tolerance or np.abs(np.radians(angle)) < tolerance:
+        (u, v), (lu, lv) = ase.geometry.conditional_find_mic([u, v], cell=None, pbc=None)
         nu = u / lu
         nv = v / lv
-        if np.abs((np.arccos(np.dot(nu, (np.array([1, -1, 1]))))) - np.pi) < tolerance:
-            w = np.cross(nu, ([-1, 1, 1]))
+
+        # Normalize auxiliary vector and check collinearity (parallel or anti-parallel)
+        aux_normalized = np.array([1, -1, 1]) / np.sqrt(3)
+        arccos_val = np.arccos(np.clip(np.dot(nu, aux_normalized), -1, 1))
+        # If nu is parallel (arccos ≈ 0) or anti-parallel (arccos ≈ π) to auxiliary, swap
+        if np.abs(arccos_val) < tolerance or np.abs(arccos_val - np.pi) < tolerance:
+            w = np.cross(nu, [-1, 1, 1])
         else:
-            w = np.cross(nu, ([1, -1, 1]))
+            w = np.cross(nu, [1, -1, 1])
 
         nw = w / np.linalg.norm(w)
-        d_ba1 = (((np.cross(nu, nw))/np.linalg.norm(u)))
-        d_ba2 = (-1 * ((np.cross(nu, nw))/np.linalg.norm(u))) + (-1 * ((np.cross(nw, nv))/np.linalg.norm(v))) # equation to calculate dBA/dx [1]
-        d_ba3 = ((np.cross(nw, nv))/np.linalg.norm(v))
-        d_ba=np.array([[d_ba1[0], d_ba2[0], d_ba3[0]]])
+        d_ba1 = np.cross(nu, nw) / np.linalg.norm(u)
+        d_ba2 = (-np.cross(nu, nw) / np.linalg.norm(u)) + (-np.cross(nw, nv) / np.linalg.norm(v))
+        d_ba3 = np.cross(nw, nv) / np.linalg.norm(v)
+        d_ba = np.array([[d_ba1[0], d_ba2[0], d_ba3[0]]])
 
     else:
         d_ba = np.radians(ase.geometry.get_angles_derivatives(u, v))


### PR DESCRIPTION
## Linear angle detection in the Wilson B-matrix

Fixes #58.

### Detect linear angles with a tolerance (@4nn313n3)

`_bond_angle_derivatives()` picked the auxiliary-vector branch on exact
equality, `angle == 180 or angle == 0`. That test never fires in practice:
ASE's `get_angles()` clips `cos` to ±1 and returns `np.degrees(arccos(...))`,
so a geometrically linear angle comes back as 179.99994°, not 180.0. Linear
angles therefore fell through to `get_angles_derivatives()`, which divides by
`sin(angle)`.

Replaced by a tolerance band, matching Bakken & Helgaker (J. Chem. Phys. 117,
9160 (2002)) 

Originally authored on `ase_jedi_linear_angle_gradient_fix` against
`Jedi.get_b_matrix()` in `jedi.py`; carried over unchanged in substance to
`bmatrix.py` after the refactor.

### Fix the auxiliary-axis collinearity check

The inner guard picks a fallback axis when the molecular axis `nu` is
collinear with the default auxiliary vector `[1,-1,1]`, otherwise
`cross(nu, [1,-1,1])` is zero and `w / |w|` is NaN. Two problems:

- `[1,-1,1]` was not normalized, so `dot(nu, [1,-1,1])` is not a cosine and
  can exceed 1 in magnitude. `arccos` then returns NaN and the comparison is
  False
- Only the anti-parallel case (`arccos ≈ π`) was tested; parallel
  (`arccos ≈ 0`) is equally degenerate and was not caught.

Now normalizes by `√3`, clips before `arccos`, and tests both ends.

### Notes

Verified that widening the tolerance is not desirable: real geometries are
either numerically linear (deviation ~1e-6 rad) or chemically bent (> 5e-2
rad), with nothing in between. The auxiliary branch uses a lab-frame fixed
vector and is not rotationally covariant, so handing it more angles than
strictly necessary would be a regression.